### PR TITLE
Sorting sports in the selector

### DIFF
--- a/score-ios/ViewModels/GamesViewModel.swift
+++ b/score-ios/ViewModels/GamesViewModel.swift
@@ -300,6 +300,31 @@ class GamesViewModel: ObservableObject
     func retryFetch() {
         fetchGames()
     }
+    
+    func orderSportsByUpcoming(sports: [Sport]) -> [Sport] {
+        let allOtherSports = Sport.allCases.filter { $0 != .All }
+        let (withGames, withoutGames) = allOtherSports.reduce(into: ([Sport](), [Sport]())) { acc, sport in
+            if allUpcomingGames.contains(where: { $0.sport == sport }) {
+                acc.0.append(sport)
+            } else {
+                acc.1.append(sport)
+            }
+        }
+        let nextGameBySport: [Sport: Date] = Dictionary(uniqueKeysWithValues:
+            withGames.map { sport in
+                let nextDate = allUpcomingGames
+                    .filter { $0.sport == sport }
+                    .map { $0.date }
+                    .min() ?? Date.distantFuture
+                return (sport, nextDate)
+            }
+        )
+        let sortedWithGames = withGames.sorted { s1, s2 in
+            (nextGameBySport[s1] ?? Date.distantFuture) < (nextGameBySport[s2] ?? Date.distantFuture)
+        }
+        let sortedWithoutGames = withoutGames.sorted { $0.rawValue < $1.rawValue }
+        return [.All] + sortedWithGames + sortedWithoutGames
+    }
 }
 
 extension DataState: Equatable {

--- a/score-ios/ViewModels/GamesViewModel.swift
+++ b/score-ios/ViewModels/GamesViewModel.swift
@@ -302,7 +302,7 @@ class GamesViewModel: ObservableObject
     }
     
     func orderSportsByUpcoming(sports: [Sport]) -> [Sport] {
-        let allOtherSports = Sport.allCases.filter { $0 != .All }
+        let allOtherSports = sports.filter { $0 != .All }
         let (withGames, withoutGames) = allOtherSports.reduce(into: ([Sport](), [Sport]())) { acc, sport in
             if allUpcomingGames.contains(where: { $0.sport == sport }) {
                 acc.0.append(sport)

--- a/score-ios/Views/ListViews/SportSelectorView.swift
+++ b/score-ios/Views/ListViews/SportSelectorView.swift
@@ -16,7 +16,7 @@ struct SportSelectorView: View {
         ScrollViewReader { proxy in
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack {
-                    ForEach(Sport.allCases) { sport in
+                    ForEach(gamesVM.orderSportsByUpcoming(sports: Sport.allCases)) { sport in
                         Button {
                             highlightsVM.selectedSport = sport
                             gamesVM.selectedSport = sport


### PR DESCRIPTION
<img width="332" height="75" alt="Screenshot 2026-03-25 at 5 45 13 PM" src="https://github.com/user-attachments/assets/856e1b94-f27a-4200-ac7f-22c19de86698" />

- Added a function to GamesViewModel to return a list of sports sorted
- by the date of the games they have
- Or if there are no upcoming games, sorted alphabetically
- Changed the sports selector so that reflects this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Sports selector now dynamically reorders to show sports with upcoming games first, sorted by the earliest upcoming event date.
  * "All" remains pinned first; sports with no upcoming games are listed last and sorted alphabetically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->